### PR TITLE
fix: remove the "timezone" word in the PDF output’s introduction

### DIFF
--- a/kosmorrolib/dumper.py
+++ b/kosmorrolib/dumper.py
@@ -263,7 +263,7 @@ class _LatexDumper(Dumper):
                            "It aims to help you to prepare your observation session. "
                            "All the hours are given in {timezone}.").format(
                                date=self.get_date_as_string(),
-                               timezone='UTC+%d timezone' % self.timezone if self.timezone != 0 else 'UTC'
+                               timezone='UTC+%d' % self.timezone if self.timezone != 0 else 'UTC'
                            ),
                          _("Don't forget to check the weather forecast before you go out with your material.")
                      ])) \


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Related issues | N/A
| Has BC-break   | no
| License        | GNU AGPL-v3

**Checklist:**
- [ ] ~~I have updated the manpage~~

<!--
    Replace this notice by a short README for your feature/bugfix.
-->

