### PR TITLE
Handle KeyboardInterrupt exception

### DIFF
--- a/kosmorro
+++ b/kosmorro
@@ -23,4 +23,7 @@ from kosmorrolib.main import main
 locale.setlocale(locale.LC_ALL, '')
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(1)


### PR DESCRIPTION
Using Ctrl+C to interrupt the program won't display a big ugly error
anymore.

| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Related issues | N/A
| Has BC-break   | no
| License        | GNU AGPL-v3

**Checklist:**
- [ ] ~~I have updated the manpage~~

<!--
    Replace this notice by a short README for your feature/bugfix.
-->

