### PR TITLE
fix: remove Mercury and Venus opposition

### DIFF
--- a/kosmorrolib/events.py
+++ b/kosmorrolib/events.py
@@ -80,7 +80,7 @@ def _search_oppositions(start_time: Time, end_time: Time) -> [Event]:
     events = []
 
     for aster in ASTERS:
-        if not isinstance(aster, Planet) or aster.name in ['Mercury', 'Venus']:
+        if not isinstance(aster, Planet) or aster.skyfield_name in ['MERCURY', 'VENUS']:
             continue
 
         times, _ = find_discrete(start_time, end_time, is_oppositing)


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Related issues | N/A
| Has BC-break   | no
| License        | GNU AGPL-v3

**Checklist:**
- [ ] ~~I have updated the manpage~~

Fix Mercury and Venus being caught in the opposition computation, since these planets cannot be in opposition.